### PR TITLE
Effectively disable selinux until next reboot

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'gmiranda@chef.io'
 license 'mit'
 description 'Installs/Configures chef_portal'
 long_description 'Installs/Configures chef_portal'
-version '0.1.1'
+version '0.1.2'
 
 supports 'centos'
 supports 'amazon'

--- a/recipes/provisioner_node.rb
+++ b/recipes/provisioner_node.rb
@@ -105,6 +105,11 @@ when 'redhat', 'centos', 'fedora'
     group 'root'
     mode '0644'
   end
+
+  # enable permissive mode until next boot
+  file '/selinux/enforce' do
+    content '0'
+  end
 end
 
 service 'iptables' do


### PR DESCRIPTION
While the provisioner recipe disables SElinux, that change doesn't take effect until the system reboots.  This change temporarily sets SElinux into permissive mode (effectively disabled).  After the system reboots, SElinux will be in disabled mode.
